### PR TITLE
Helth checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,108 @@
 # goodon
 
-Goodon is a Go utility library that simplifies setting up gRPC services with integrated OpenTelemetry observability.
-
-## Features
-
-- Simple API for configuring OpenTelemetry components
-- Pre-configured OTLP exporters for sending telemetry data via gRPC
-- Unified setup for both traces and metrics
-- Proper OTel shutdown handling for clean resource management
-- Automatic tracing for gRPC requests
-- Graceful gRPC server shutdown handling
+Goodon is a Go utility library for building production-ready gRPC services. It provides opinionated defaults for server setup, HTTP/JSON and gRPC-Web gateways, health checks, and OpenTelemetry observability.
 
 ## Installation
 
 ```go
 go get github.com/vismaml/goodon
+```
+
+## Features
+
+### gRPC Server
+
+Create a gRPC server with sensible defaults (15 MB message limits, context tracing interceptors, OpenTelemetry instrumentation) and graceful shutdown handling.
+
+```go
+server := goodon.NewGRPCServer()
+
+// Or with additional options:
+server := goodon.NewGRPCServer(grpc.MaxRecvMsgSize(30 << 20))
+
+// Start with graceful shutdown on SIGINT/SIGTERM:
+if err := goodon.StartWithDefaults(server); err != nil {
+    log.Fatal(err)
+}
+```
+
+### HTTP/JSON Gateway (gRPC-Gateway)
+
+Expose your gRPC services as a REST/JSON API via [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway). Includes custom header forwarding (`x-request-id`, `vml-username`), rate-limit header passthrough, and proper HTTP 413 mapping for oversized messages.
+
+```go
+go func() {
+    if err := goodon.StartHTTPGateway(cfg.GRPCPort, cfg.HTTPPort,
+        pb.RegisterHandlerFromEndpoint,
+    ); err != nil && err != http.ErrServerClosed {
+        log.Fatalf("failed to start HTTP gateway: %v", err)
+    }
+}()
+```
+
+### gRPC-Web Gateway
+
+Serve both HTTP/JSON and gRPC-Web clients from a single port. Useful for browser-based gRPC-Web clients alongside traditional REST consumers.
+
+```go
+go func() {
+    if err := goodon.StartGRPCGatewayWithWeb(grpcServer, cfg.GRPCPort, cfg.HTTPPort,
+        pb.RegisterHandlerFromEndpoint,
+    ); err != nil && err != http.ErrServerClosed {
+        log.Fatalf("failed to start HTTP gateway with gRPC-Web: %v", err)
+    }
+}()
+```
+
+The `GRPCWebProxy` can also be used standalone with any HTTP handler:
+
+```go
+proxy := goodon.NewGRPCWebProxy(grpcServer)
+http.ListenAndServe(":8080", proxy.Handler(myHTTPHandler))
+```
+
+### Health Checks
+
+Both gateway functions automatically expose health check endpoints for Kubernetes probes:
+
+- `/healthz` — liveness probe, returns `200` if the gateway process is running.
+- `/readyz` — readiness probe, checks the upstream gRPC server via the [gRPC Health Checking Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). Returns `503` if the upstream is unreachable.
+
+Your gRPC server must register the health service for `/readyz` to work:
+
+```go
+import "google.golang.org/grpc/health"
+import "google.golang.org/grpc/health/grpc_health_v1"
+
+healthServer := health.NewServer()
+grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+```
+
+Kubernetes probe configuration:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 8080
+```
+
+### OpenTelemetry
+
+Initialize traces and metrics with OTLP gRPC exporters in one call. Sets up global tracer and meter providers with proper shutdown handling.
+
+```go
+shutdown, err := goodon.StartTelemetryWithDefaults("my-service", cfg.HostIP)
+if err != nil {
+    log.Fatal(err)
+}
+defer shutdown()
+
+// Use the global tracer and meter:
+ctx, span := goodon.Tracer.Start(ctx, "operation")
+defer span.End()
 ```

--- a/grpcgateway.go
+++ b/grpcgateway.go
@@ -91,7 +91,7 @@ func StartHTTPGateway(grpcPort, httpPort string, registerFuncs ...RegisterFunc) 
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      healthHandler(mux, grpcEndpoint),
+		Handler:      healthHandler(mux),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,
@@ -148,7 +148,7 @@ func StartGRPCGatewayWithWeb(grpcServer *grpc.Server, grpcPort, httpPort string,
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      healthHandler(combinedHandler, grpcEndpoint),
+		Handler:      healthHandler(combinedHandler),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,

--- a/grpcgateway.go
+++ b/grpcgateway.go
@@ -91,7 +91,7 @@ func StartHTTPGateway(grpcPort, httpPort string, registerFuncs ...RegisterFunc) 
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      mux,
+		Handler:      healthHandler(mux, grpcEndpoint),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,
@@ -148,7 +148,7 @@ func StartGRPCGatewayWithWeb(grpcServer *grpc.Server, grpcPort, httpPort string,
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      combinedHandler,
+		Handler:      healthHandler(combinedHandler, grpcEndpoint),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,

--- a/grpcgateway.go
+++ b/grpcgateway.go
@@ -91,7 +91,7 @@ func StartHTTPGateway(grpcPort, httpPort string, registerFuncs ...RegisterFunc) 
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      healthHandler(mux, grpcEndpoint),
+		Handler:      withHealthCheck(mux, grpcEndpoint),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,
@@ -148,7 +148,7 @@ func StartGRPCGatewayWithWeb(grpcServer *grpc.Server, grpcPort, httpPort string,
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      healthHandler(combinedHandler, grpcEndpoint),
+		Handler:      withHealthCheck(combinedHandler, grpcEndpoint),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,

--- a/grpcgateway.go
+++ b/grpcgateway.go
@@ -91,7 +91,7 @@ func StartHTTPGateway(grpcPort, httpPort string, registerFuncs ...RegisterFunc) 
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      healthHandler(mux),
+		Handler:      healthHandler(mux, grpcEndpoint),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,
@@ -148,7 +148,7 @@ func StartGRPCGatewayWithWeb(grpcServer *grpc.Server, grpcPort, httpPort string,
 
 	server := &http.Server{
 		Addr:         ":" + httpPort,
-		Handler:      healthHandler(combinedHandler),
+		Handler:      healthHandler(combinedHandler, grpcEndpoint),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  30 * time.Second,

--- a/health.go
+++ b/health.go
@@ -10,11 +10,11 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
 
-// healthHandler wraps an http.Handler with /healthz and /readyz endpoints.
+// withHealthCheck wraps an http.Handler with /healthz and /readyz endpoints.
 // /healthz is a liveness probe that always returns 200.
 // /readyz is a readiness probe that checks the upstream gRPC server is reachable
 // and serving via the gRPC Health Checking Protocol.
-func healthHandler(next http.Handler, grpcEndpoint string) http.Handler {
+func withHealthCheck(next http.Handler, grpcEndpoint string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":

--- a/health.go
+++ b/health.go
@@ -1,53 +1,16 @@
 package goodon
 
-import (
-	"context"
-	"net/http"
-	"time"
+import "net/http"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/health/grpc_health_v1"
-)
-
-// healthHandler wraps an http.Handler with /healthz and /readyz endpoints.
-// /healthz is a liveness probe that always returns 200.
-// /readyz is a readiness probe that checks the upstream gRPC server is reachable
-// and serving via the gRPC Health Checking Protocol.
-func healthHandler(next http.Handler, grpcEndpoint string) http.Handler {
+// healthHandler wraps an http.Handler with a /healthz endpoint.
+// /healthz is a health probe that always returns 200, indicating the gateway is running.
+func healthHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/healthz":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
-			return
-		case "/readyz":
-			if err := checkGRPCHealth(grpcEndpoint); err != nil {
-				http.Error(w, err.Error(), http.StatusServiceUnavailable)
-				return
-			}
+		if r.URL.Path == "/healthz" {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
-}
-
-// checkGRPCHealth dials the upstream gRPC server and calls the Health service.
-func checkGRPCHealth(endpoint string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-
-	conn, err := grpc.NewClient(endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	client := grpc_health_v1.NewHealthClient(conn)
-	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
-	return err
 }

--- a/health.go
+++ b/health.go
@@ -2,6 +2,7 @@ package goodon
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"time"
 
@@ -15,6 +16,13 @@ import (
 // /readyz is a readiness probe that checks the upstream gRPC server is reachable
 // and serving via the gRPC Health Checking Protocol.
 func withHealthCheck(next http.Handler, grpcEndpoint string) http.Handler {
+	conn, err := grpc.NewClient(grpcEndpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatalf("failed to create health check client: %v", err)
+	}
+	healthClient := grpc_health_v1.NewHealthClient(conn)
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
@@ -22,32 +30,26 @@ func withHealthCheck(next http.Handler, grpcEndpoint string) http.Handler {
 			_, _ = w.Write([]byte("ok"))
 			return
 		case "/readyz":
-			if err := checkGRPCHealth(grpcEndpoint); err != nil {
+			resp, err := checkGRPCHealth(r.Context(), healthClient)
+			if err != nil {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)
 				return
 			}
+			if resp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
+				http.Error(w, resp.GetStatus().String(), http.StatusServiceUnavailable)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
+			_, _ = w.Write([]byte(resp.GetStatus().String()))
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
 }
 
-// checkGRPCHealth dials the upstream gRPC server and calls the Health service.
-func checkGRPCHealth(endpoint string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+// checkGRPCHealth calls the gRPC Health Checking Protocol on the upstream server.
+func checkGRPCHealth(ctx context.Context, client grpc_health_v1.HealthClient) (*grpc_health_v1.HealthCheckResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
-
-	conn, err := grpc.NewClient(endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	client := grpc_health_v1.NewHealthClient(conn)
-	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
-	return err
+	return client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
 }

--- a/health.go
+++ b/health.go
@@ -1,16 +1,53 @@
 package goodon
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+	"time"
 
-// healthHandler wraps an http.Handler with a /healthz endpoint.
-// /healthz is a health probe that always returns 200, indicating the gateway is running.
-func healthHandler(next http.Handler) http.Handler {
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// healthHandler wraps an http.Handler with /healthz and /readyz endpoints.
+// /healthz is a liveness probe that always returns 200.
+// /readyz is a readiness probe that checks the upstream gRPC server is reachable
+// and serving via the gRPC Health Checking Protocol.
+func healthHandler(next http.Handler, grpcEndpoint string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/healthz" {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		case "/readyz":
+			if err := checkGRPCHealth(grpcEndpoint); err != nil {
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ok"))
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// checkGRPCHealth dials the upstream gRPC server and calls the Health service.
+func checkGRPCHealth(endpoint string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	return err
 }

--- a/health.go
+++ b/health.go
@@ -1,0 +1,53 @@
+package goodon
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// healthHandler wraps an http.Handler with /healthz and /readyz endpoints.
+// /healthz is a liveness probe that always returns 200.
+// /readyz is a readiness probe that checks the upstream gRPC server is reachable
+// and serving via the gRPC Health Checking Protocol.
+func healthHandler(next http.Handler, grpcEndpoint string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		case "/readyz":
+			if err := checkGRPCHealth(grpcEndpoint); err != nil {
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// checkGRPCHealth dials the upstream gRPC server and calls the Health service.
+func checkGRPCHealth(endpoint string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	conn, err := grpc.NewClient(endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := grpc_health_v1.NewHealthClient(conn)
+	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+	return err
+}

--- a/health.go
+++ b/health.go
@@ -26,10 +26,6 @@ func withHealthCheck(next http.Handler, grpcEndpoint string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/healthz":
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("ok"))
-			return
-		case "/readyz":
 			resp, err := checkGRPCHealth(r.Context(), healthClient)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusServiceUnavailable)


### PR DESCRIPTION
Add health and readiness checks for http / web-grpc gateways. Because k8s allows only 1 health check endpoint per container, the health check of the upstream service was implemented.